### PR TITLE
Example makefile for a better development workflow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
+ZIPI_REPO = https://github.com/udem-dlteam/zipi
 ZIPI_BRANCH = master
 PYTHON38 = python3
 
 zipi:
-	git clone https://github.com/udem-dlteam/zipi $@
+	git clone $(ZIPI_REPO) $@
 	cd zipi && git checkout $(ZIPI_BRANCH)
 
 .PHONY: zipi-pull

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,14 @@ pyinterp: zipi-pull
 	@echo "Running make on the parser..."
 	cd zipi/parser && $(MAKE)
 	@echo "Running make on zp..."
-	cd zipi/etc/bootstrap && $(MAKE) copy_files && python3 zp.py -f _tmpdir/pyinterp.py
+	cd zipi/etc/bootstrap && $(MAKE) copy_files && $(PYTHON38) zp.py -f _tmpdir/pyinterp.py
 	@echo "Copying pyinterp.js..."
 	cp --backup=numbered zipi/etc/bootstrap/_tmpdir/pyinterp.js ./include/lang/py/pyinterp.js
 	@echo "Done."
 
 .PHONY: serve
 serve: pyinterp
-	python3 -m http.server 8999 --bind 127.0.0.1
+	$(PYTHON38) -m http.server 8999 --bind 127.0.0.1
 
 clean:
 	rm -rf ./zipi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+ZIPI_BRANCH = master
+PYTHON38 = python3
+
 zipi:
-	git clone --single-branch --branch zp_tests https://github.com/belmarca/zipi $@
+	git clone https://github.com/udem-dlteam/zipi $@
+	cd zipi && git checkout $(ZIPI_BRANCH)
 
 .PHONY: zipi-pull
 zipi-pull: zipi
@@ -14,7 +18,9 @@ pyinterp: zipi-pull
 	cp --backup=numbered zipi/etc/bootstrap/_tmpdir/pyinterp.js ./include/lang/py/pyinterp.js
 	@echo "Done."
 
-
 .PHONY: serve
 serve: pyinterp
 	python3 -m http.server 8999 --bind 127.0.0.1
+
+clean:
+	rm -rf ./zipi

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ pyinterp: zipi-pull
 	@echo "Running make on the parser..."
 	cd zipi/parser && $(MAKE)
 	@echo "Running make on zp..."
-	cd zipi/etc/bootstrap && $(MAKE) copy_files && $(PYTHON38) zp.py -f _tmpdir/pyinterp.py
+	cd zipi/etc/bootstrap && $(MAKE) pyinterp
+	@echo "Backing up old pyinterp.js..."
+	cp ./include/lang/py/pyinterp.js ./include/lang/py/pyinterp.js.bk
 	@echo "Copying pyinterp.js..."
-	cp --backup=numbered zipi/etc/bootstrap/_tmpdir/pyinterp.js ./include/lang/py/pyinterp.js
+	cp zipi/etc/bootstrap/_tmpdir/pyinterp.js ./include/lang/py/pyinterp.js
 	@echo "Done."
 
 .PHONY: serve

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+zipi:
+	git clone --single-branch --branch zp_tests https://github.com/belmarca/zipi $@
+
+.PHONY: zipi-pull
+zipi-pull: zipi
+	@cd zipi && git pull
+
+pyinterp: zipi-pull
+	@echo "Running make on the parser..."
+	cd zipi/parser && $(MAKE)
+	@echo "Running make on zp..."
+	cd zipi/etc/bootstrap && $(MAKE) copy_files && python3 zp.py -f _tmpdir/pyinterp.py
+	@echo "Copying pyinterp.js..."
+	cp --backup=numbered zipi/etc/bootstrap/_tmpdir/pyinterp.js ./include/lang/py/pyinterp.js
+	@echo "Done."
+
+
+.PHONY: serve
+serve: pyinterp
+	python3 -m http.server 8999 --bind 127.0.0.1


### PR DESCRIPTION
This makefile allows to clone, pull and make pyinterp from the zipi repository. It currently pulls my own branch which contains changes that have yet to be upstreamed.