### PR TITLE
pass syntaxError hook to pyinterp.comp

### DIFF
--- a/include/lang/py/py.js
+++ b/include/lang/py/py.js
@@ -119,16 +119,18 @@ LangPy.prototype.compile = function (source, container, reboot) {
     }
 
     var lang = this;
+    var external_context =
+      {
+        syntaxError: syntaxError
+      };
     var ast = pyinterp.parse(source,
                              '<unknown>',
                              'exec',
-                             {
-                                 syntaxError: syntaxError
-                             });
+                             external_context);
 
     attach_to_container(ast, container);
 
-    var code = pyinterp.comp(ast);
+    var code = pyinterp.comp(ast, external_context);
 
     if (code === null) // empty program?
         return null;


### PR DESCRIPTION
requires https://github.com/udem-dlteam/zipi/pull/218 to work properly