### PR TITLE
fix renaming

### DIFF
--- a/include/fs.js
+++ b/include/fs.js
@@ -1073,10 +1073,6 @@ CodeBootFileEditor.prototype.rename = function () {
 
     fe.renameTabEvents();
 
-    inputBox.addEventListener('focusout', function (event) {
-        doneRenaming();
-    });
-
     inputBox.addEventListener('keydown', function (event) {
         if (event.keyCode === 27) {
             event.stopPropagation();


### PR DESCRIPTION
Not sure if the difference is visible, but this listener doesn't seems to get triggered at all.
Fix renaming, tested on manjaro/Chrome && manjaro/firefox